### PR TITLE
fix speaker notes printing

### DIFF
--- a/big-printer.js
+++ b/big-printer.js
@@ -33,10 +33,11 @@ var child = execFile(binPath, [
     })
     .filter(Boolean)
     .reduce(function (memo, note) {
-      memo[note.page] = note.message
-        .replace(/%c\d+:\s/, ' ')
-        .replace(/padding:5px;.*/, ' ')
-        .replace('\n', ' ');
+      memo[note.page] = (memo[note.page] || '') + '<p>' +
+        note.message
+        .replace(/%c%s: %s/, ' ')
+        .replace(/padding:5px.*?; [0-9]+ /, ' ')
+        .replace('\n', ' ') + '</p>\n';
       return memo;
     }, {});
 

--- a/lib/template.hbs
+++ b/lib/template.hbs
@@ -10,7 +10,7 @@
   {{#each slides}}
   <div class="clearfix py2">
     <div class="col lg-col-6"><img class='border' src='{{image}}' /></div>
-    <div class="col lg-col-6"><div class='px2'>{{note}}</div></div>
+    <div class="col lg-col-6"><div class='px2'>{{{note}}}</div></div>
   </div>
   {{/each}}
 </div>


### PR DESCRIPTION
Fixes https://github.com/tmcw/big-printer/issues/6

Also makes multiple `<notes>` per slide show up as multiple paragraphs (previously only the last speaker note of a slide was printed).